### PR TITLE
Force run under python2

### DIFF
--- a/sjcam
+++ b/sjcam
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 #  sjcam - SJCAM WiFi Camera CLI utility - control SJCAM sports cameras over WiFi connection
 # 


### PR DESCRIPTION
sjcam is running python2 code. Avoid python executable for systems that use that for python3 and specifically use python2